### PR TITLE
Diffing

### DIFF
--- a/src/reactiveData.ml
+++ b/src/reactiveData.ml
@@ -24,7 +24,7 @@ module type DATA = sig
   val map_patch : ('a -> 'b) -> 'a patch -> 'b patch
   val map_data : ('a -> 'b) -> 'a data -> 'b data
   val empty : 'a data
-  val eq : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
+  val equal : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
   val diff : 'a data -> 'a data -> eq:('a -> 'a -> bool) -> 'a patch
 end
 module type S = sig
@@ -140,7 +140,7 @@ struct
         let d = let f v' v = v', v in React.S.diff f s
         and f acc ((l', m'), (l, _)) =
           match acc with
-          | `Fst acc when (D.eq eq' l l0) ->
+          | `Fst acc when (D.equal eq' l l0) ->
             `Nth (f acc m')
           | `Fst acc ->
             let acc = f acc (Set l') in
@@ -374,10 +374,10 @@ module DataList = struct
     else
       List.fold_left (fun l x -> merge_p x l) l p
 
-  let rec eq eq' l1 l2 =
+  let rec equal f l1 l2 =
     match l1, l2 with
-    | x1 :: l1, x2 :: l2 when eq' x1 x2 ->
-      eq eq' l1 l2
+    | x1 :: l1, x2 :: l2 when f x1 x2 ->
+      equal f l1 l2
     | [], [] ->
       true
     | _ :: _ , _ :: _
@@ -551,7 +551,7 @@ module RMap(M : Map.S) = struct
 
     let empty = M.empty
 
-    let eq f = M.equal f
+    let equal f = M.equal f
 
     let diff x y ~eq =
       let m =

--- a/src/reactiveData.ml
+++ b/src/reactiveData.ml
@@ -156,12 +156,15 @@ struct
     | Const c -> React.S.const c
     | React (_, s) -> React.S.Pair.fst s
 
-  let make_from_s ?(eq = (=)) signal =
-    let event =
-      let f l' l = Patch (D.diff ~eq l l') in
-      React.S.diff f signal
-    and v = React.S.value signal in
-    make_from ~eq v event
+  let make_from_s ?(eq = (=)) (signal : 'a data React.S.t) =
+    let signal : ('a data * 'a msg) React.S.t =
+      let e =
+        let f l' l = l', Patch (D.diff ~eq l l') in
+        React.S.diff f signal
+      and v = let l = React.S.value signal in l, Set l in
+      React.S.hold v e
+    in
+    React (eq, signal)
 
 end
 

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -24,6 +24,10 @@ module type DATA = sig
   val map_patch : ('a -> 'b) -> 'a patch -> 'b patch
   val map_data : ('a -> 'b) -> 'a data -> 'b data
   val empty : 'a data
+  val diff :
+    'a data -> 'a data ->
+    eq:('a -> 'a -> bool) ->
+    'a patch
 end
 module type S = sig
   type 'a data
@@ -32,8 +36,9 @@ module type S = sig
   type 'a handle
   type 'a t
   val empty : 'a t
-  val make : 'a data -> 'a t * 'a handle
-  val make_from : 'a data -> 'a msg React.E.t -> 'a t
+  val make : ?eq:('a -> 'a -> bool) -> 'a data -> 'a t * 'a handle
+  val make_from :
+    ?eq:('a -> 'a -> bool) -> 'a data -> 'a msg React.E.t -> 'a t
   val make_from_s : 'a data React.S.t -> 'a t
   val const : 'a data -> 'a t
   val patch : 'a handle -> 'a patch -> unit
@@ -74,5 +79,6 @@ sig
   val filter : ('a -> unit) -> 'a t -> [`Not_implemented]
 end
 
-module RMap(M : Map.S) : S with type 'a data = 'a M.t
-                            and type 'a patch = [ `Add of M.key * 'a | `Del of M.key ]
+module RMap(M : Map.S) : S
+  with type 'a data = 'a M.t
+   and type 'a patch = [ `Add of M.key * 'a | `Del of M.key ] list

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -47,7 +47,10 @@ module type S = sig
   val map_msg : ('a -> 'b) -> 'a msg -> 'b msg
   val map : ('a -> 'b) -> 'a t -> 'b t
   val value : 'a t -> 'a data
-  val fold : ('a -> 'b msg -> 'a) -> 'b t -> 'a -> 'a React.signal
+  val fold :
+    ?eq:('a -> 'a -> bool) ->
+    ('a -> 'b msg -> 'a) ->
+    'b t -> 'a -> 'a React.signal
   val value_s : 'a t -> 'a data React.S.t
   val event : 'a t -> 'a msg React.E.t
 end

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -24,10 +24,8 @@ module type DATA = sig
   val map_patch : ('a -> 'b) -> 'a patch -> 'b patch
   val map_data : ('a -> 'b) -> 'a data -> 'b data
   val empty : 'a data
-  val diff :
-    'a data -> 'a data ->
-    eq:('a -> 'a -> bool) ->
-    'a patch
+  val eq : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
+  val diff : 'a data -> 'a data -> eq:('a -> 'a -> bool) -> 'a patch
 end
 module type S = sig
   type 'a data
@@ -45,7 +43,7 @@ module type S = sig
   val patch : 'a handle -> 'a patch -> unit
   val set : 'a handle -> 'a data -> unit
   val map_msg : ('a -> 'b) -> 'a msg -> 'b msg
-  val map : ('a -> 'b) -> 'a t -> 'b t
+  val map : ?eq:('b -> 'b -> bool) -> ('a -> 'b) -> 'a t -> 'b t
   val value : 'a t -> 'a data
   val fold :
     ?eq:('a -> 'a -> bool) ->

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -39,7 +39,8 @@ module type S = sig
   val make : ?eq:('a -> 'a -> bool) -> 'a data -> 'a t * 'a handle
   val make_from :
     ?eq:('a -> 'a -> bool) -> 'a data -> 'a msg React.E.t -> 'a t
-  val make_from_s : 'a data React.S.t -> 'a t
+  val make_from_s :
+    ?eq:('a -> 'a -> bool) -> 'a data React.S.t -> 'a t
   val const : 'a data -> 'a t
   val patch : 'a handle -> 'a patch -> unit
   val set : 'a handle -> 'a data -> unit

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -24,7 +24,7 @@ module type DATA = sig
   val map_patch : ('a -> 'b) -> 'a patch -> 'b patch
   val map_data : ('a -> 'b) -> 'a data -> 'b data
   val empty : 'a data
-  val eq : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
+  val equal : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
   val diff : 'a data -> 'a data -> eq:('a -> 'a -> bool) -> 'a patch
 end
 module type S = sig

--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -25,7 +25,7 @@ module type DATA = sig
   val map_data : ('a -> 'b) -> 'a data -> 'b data
   val empty : 'a data
   val equal : ('a -> 'a -> bool) -> 'a data -> 'a data -> bool
-  val diff : 'a data -> 'a data -> eq:('a -> 'a -> bool) -> 'a patch
+  val diff : eq:('a -> 'a -> bool) -> 'a data -> 'a data -> 'a patch
 end
 module type S = sig
   type 'a data


### PR DESCRIPTION
This patch implements a diffing algorithm. When a "set" operation is performed (either directly by the client, or via the implementation of `make_from_s`) we diff the old data structure contents with the new contents, and export incremental patches.

The diffing algorithm for lists is based on computing the longest common subsequence (based on standard recursion plus memoization). This is of quadratic complexity in the worst case, but I suspect our implementation performs decently in practice.

Most functions have gained an `?eq` argument, which may be crucial for diffing; it depends on the contents. Note that diffing happens "early", e.g., if the input is a list of integers which is turned into a list of DOM nodes via `map`, then we diff lists of integers. In this example, there is no need to pass `~eq` (the default `(=)` is just fine for integers). This early diffing means that we can avoid RPCs, DB queries, rebuilding DOM nodes and other complicated operations that happen downstream.

As a side-effect, the mutable lists kept internally have been replaced by signals. I think the new implementation of `fold` fixes #9.