### PR TITLE
Correct the documentation for RList.move

### DIFF
--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -159,8 +159,8 @@ sig
       corresponding to [h] with [v] *)
   val update : 'a -> int -> 'a handle -> unit
 
-  (** [move i j h] moves the [i]-th element of the container
-      corresponding to [h] to the [j]-th position, modifying the
+  (** [move i offset h] moves the [i]-th element of the container
+      corresponding by [offset] positions in [h], modifying the
       indices of other elements *)
   val move : int -> int -> 'a handle -> unit
 


### PR DESCRIPTION
I'm not sure if the documentation should be changed to match the implementation or vice-versa, so I'm doing the one with the smallest diff.