### PR TITLE
RList.filter using inner type repr by splitting modules

### DIFF
--- a/src/reactiveData.mli
+++ b/src/reactiveData.mli
@@ -32,7 +32,6 @@
 module type S = sig
 
   (** Reactive version of the data container *)
-  type 'a t
 
   (** Raw (non-reactive) version of the data container *)
   type 'a data
@@ -46,6 +45,8 @@ module type S = sig
                             on the current contents *)
     | Set of 'a data    (** With [Set d], [d] becomes the new
                             content *)
+
+  type 'a t
 
   (** Handle that permits applying incremental updates *)
   type 'a handle
@@ -176,6 +177,8 @@ sig
 
   (** Produce container list containing a single, constant element *)
   val singleton : 'a -> 'a t
+
+  val filter : ('a -> bool) -> 'a t -> 'a t
 
   (** Produce reactive list containing a single element that gets
       updated based on a signal *)


### PR DESCRIPTION
I splitted the modules sigs 

DATA / DATA'
S / S'

and also the functor Make. 
This is not visible for the outside.

The most important part of the code is `filter_patch` which propagates the new positions of the next patches when an insert is removed.  
