### PR TITLE
doc: migrate the documentation to odoc + wodoc

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,10 +6,15 @@ name: Documentation
 on:
   push:
     branches: [master]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Publish a stable version: freeze the dev docs now on gh-pages as /<version>/ and repoint `latest` (e.g. 1.2.3). Leave empty to just rebuild dev."
+        required: false
+        default: ""
 jobs:
   build-deploy:
-    if: github.repository == 'ocsigen/reactiveData'
+    if: github.repository == 'ocsigen/reactiveData' && (github.event_name != 'workflow_dispatch' || github.event.inputs.version == '')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,3 +44,46 @@ jobs:
           folder: _doc-site/dev
           target-folder: dev
           clean: true
+
+  release:
+    # Manual run with a version: freeze the dev docs currently on gh-pages as the
+    # stable /<version>/ and repoint `latest` at it (refreshing versions.json).
+    # No rebuild -- the docs of a release are exactly the dev docs at that point.
+    if: github.repository == 'ocsigen/reactiveData' && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: "5.4.0"
+
+      - name: Install wodoc
+        run: |
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 0
+
+      - name: Freeze dev as the stable version and repoint latest
+        # wodoc release: cp -a site/dev site/<version>, ln -sfn <version> latest,
+        # write the root index.html redirect if missing, refresh versions.json.
+        run: >-
+          opam exec -- wodoc release --site site --from dev
+          --version "${{ github.event.inputs.version }}"
+
+      - name: Commit and push gh-pages
+        run: |
+          cd site
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Release doc ${{ github.event.inputs.version }} (freeze dev, repoint latest)"
+          git push

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,54 +1,41 @@
-name: Deploy odoc to GitHub Pages
-
+# Build the documentation with odoc, theme it with the Ocsigen chrome (wodoc),
+# and publish it on the project's gh-pages branch (https://ocsigen.org/reactiveData/).
+# See doc/README.md. CI deploys ONLY dev/ from master; stable versions are frozen
+# at release time (`wodoc release`). No client/server split -> plain dune @doc.
+name: Documentation
 on:
   push:
-    branches:
-      - master
-
-permissions: read-all
-
-concurrency:
-  group: deploy-odoc
-  cancel-in-progress: true
-
+    branches: [master]
+  workflow_dispatch: {}
 jobs:
-  deploy-odoc:
-    name: Deploy odoc to GitHub Pages
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    permissions:
-      contents: read
-      id-token: write
-      pages: write
-
+  build-deploy:
+    if: github.repository == 'ocsigen/reactiveData'
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
-      - name: Checkout tree
-        uses: actions/checkout@v6
-
-      - name: Set-up OCaml
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
-
+          ocaml-compiler: "5.4.0"
       - name: Install dependencies
-        run: opam install . --deps-only --with-doc
-
-      - name: Build documentation
-        run: opam exec -- dune build @doc
-
-      - name: Set-up Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        run: |
+          opam install . --deps-only --with-doc
+          opam pin add -n wodoc https://github.com/ocsigen/wodoc.git
+          opam install wodoc odoc
+      - name: Build documentation (dev)
+        run: >-
+          opam exec -- wodoc build --config doc/wodoc
+          --menu https://ocsigen.org/doc/menu.html
+          --out "$PWD/_doc-site/dev" --label dev
+      - name: Deploy to gh-pages (replace only dev/, keep the rest)
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: _build/default/_doc/_html
-
-      - name: Deploy odoc to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: _doc-site/dev
+          target-folder: dev
+          clean: true

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,58 @@
+# How the ReactiveData documentation is generated
+
+The ReactiveData documentation published at <https://ocsigen.org/reactiveData/>
+is built with **odoc** and themed with the Ocsigen site chrome by
+[**wodoc**](https://github.com/ocsigen/wodoc) (an odoc driver). The same odoc
+sources are also what ocaml.org renders.
+
+## Sources
+
+| What | Where | Format |
+|---|---|---|
+| API | the `.mli` of `reactiveData` (the `ReactiveData` module) | odoc comments |
+| Site configuration (nav, …) | [`doc/wodoc`](wodoc) | wodoc config (S-expression) |
+
+ReactiveData is a single-module library with no manual, so a plain
+`dune build @doc --profile release` builds the API. The page theming and the
+left navigation are declared in [`doc/wodoc`](wodoc) — an S-expression with the
+project metadata, the `(nav …)` left menu, and `(manual-root)` (single-package:
+deploy at the version root, so URLs are `/reactiveData/<version>/…` rather than
+`/reactiveData/<version>/reactiveData/…`). See the
+[wodoc README](https://github.com/ocsigen/wodoc) for the config syntax.
+
+## Build
+
+```
+wodoc build --config doc/wodoc --label dev --out _doc-site/dev \
+  --menu https://ocsigen.org/doc/menu.html
+```
+
+`wodoc build` runs `dune build @doc`, assembles every page into the Ocsigen site
+(shared header/menu/drawer, the version `<select>`, the left navigation from
+`doc/wodoc`). `--menu` is fetched from its single canonical copy in
+`ocsigen.github.io`. Add `--local` to also fetch the shared `/css//img/` assets
+and preview offline.
+
+## Deployment (CI)
+
+[`.github/workflows/doc.yml`](../.github/workflows/doc.yml) builds and publishes
+to the project's **`gh-pages`** branch (served at `ocsigen.org/reactiveData/`).
+On **push to `master`** it rebuilds and deploys the **`dev`** docs only. Each run
+replaces only the `dev/` directory; the other version directories already on
+`gh-pages` are preserved.
+
+## Releasing a stable version
+
+The CI builds only `dev/`. To publish a stable version, run the **Documentation**
+workflow manually (GitHub → Actions → *Documentation* → "Run workflow") with the
+**version** input (e.g. `0.3.1`). The `release` job freezes the current `dev/`
+docs as `/<version>/`, repoints the `latest` symlink, writes the root redirect
+and refreshes `versions.json` — via `wodoc release --from dev --version <version>`.
+No rebuild: the docs of a release are exactly the `dev` docs at that point.
+
+Equivalently, by hand on a `gh-pages` checkout:
+
+```
+wodoc release --site . --from dev --version <version>
+git add -A && git commit -m "Release doc <version>" && git push
+```

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -6,6 +6,7 @@
 (project reactiveData)
 (title ReactiveData)
 (pub /reactiveData)
+(manual-root)
 (profile release)                       ; dune build @doc --profile release
 (landing reactiveData/index.html)
 ;; no (highlight …): ReactiveData has no ppx, so wodoc's default starter is enough.

--- a/doc/wodoc
+++ b/doc/wodoc
@@ -1,0 +1,16 @@
+;; Declarative wodoc config for the ReactiveData documentation.
+;; Built by `wodoc build` (no client/server split, no manual): a single library
+;; with one module, so a plain `dune build @doc` is enough.
+;;   wodoc build --config doc/wodoc --out <dir>/<label> \
+;;               --label <v> --menu <shared menu.html> [--latest]
+(project reactiveData)
+(title ReactiveData)
+(pub /reactiveData)
+(profile release)                       ; dune build @doc --profile release
+(landing reactiveData/index.html)
+;; no (highlight …): ReactiveData has no ppx, so wodoc's default starter is enough.
+(packages reactiveData)
+(nav
+  (section "ReactiveData"
+    (link "Overview"     reactiveData/index.html              reactiveData)
+    (link "ReactiveData" reactiveData/ReactiveData/index.html reactiveData)))


### PR DESCRIPTION
Adds the wodoc config + Documentation workflow so reactiveData's docs are built with the shared odoc + wodoc pipeline (`dune build @doc`) and published to its own gh-pages.

Draft — part of the cross-project Ocsigen doc migration to wodoc.