### PR TITLE
doc: update doc/wodoc for wodoc's new defaults

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -5,7 +5,8 @@
 ;;               --label <v> --menu <shared menu.html> [--latest]
 (project reactiveData)
 (title ReactiveData)
-(pub /reactiveData)
+(url-prefix /reactiveData)
+(css /css/style.css /css/ocsigen-odoc.css)  ; shared Ocsigen theme (wodoc css default changed)
 (manual-root)
 (profile release)                       ; dune build @doc --profile release
 (landing reactiveData/index.html)


### PR DESCRIPTION
Targets the `wodoc-doc` branch (where ReactiveData's wodoc setup lives; not yet on master). wodoc master now ships a built-in default theme and renames `pub` → `url-prefix`:

- add `(css /css/style.css /css/ocsigen-odoc.css)` to keep the shared Ocsigen theme (wodoc's css default changed to a self-contained built-in theme);
- rename `(pub …)` → `(url-prefix …)`.

Merge this into `wodoc-doc` so that branch is ready to go live with the new wodoc.